### PR TITLE
[crypt]: file access problem with encrypt xlator in case one brick is offline

### DIFF
--- a/xlators/encryption/crypt/src/crypt.c
+++ b/xlators/encryption/crypt/src/crypt.c
@@ -3427,6 +3427,8 @@ crypt_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (xdata)
         local->xdata = dict_ref(xdata);
     gf_uuid_copy(local->loc->gfid, buf->ia_gfid);
+    gf_uuid_copy(inode->gfid, buf->ia_gfid);
+    inode->ia_type = IA_IFREG;
 
     STACK_WIND(frame, load_file_size, FIRST_CHILD(this),
                FIRST_CHILD(this)->fops->getxattr, local->loc,


### PR DESCRIPTION


Problem:
setup: replica x3 no distribution using encrypt xlator.
if 3 bricks are up all clients are able to access all the files.
if one brick goes down, every client is able to access the files that created.
first lookup is triggered with filename. Then nameless lookup is triggered with gfid and then, finaly, getxattr for trusted.glusterfs.crypt.att.size.
In case the file is created from own client last lookup includes the gfid but if the file is created from different client, although gfid is returned from the first lookup from server, it is not included in the nameless lookup.
This results error from server which of course causes failure in the whole operation.

Solution:
In crypt_lookup_cbk in case type is IA_IFREG the returned gfid from buf->ia_gfid copied in the inode->gfid.

Change-Id: Id2d8a052f55050134241e2f097eb78278a86c78b
fixes: bz#1656000
Signed-off-by: kinsu <vpolakis@gmail.com>