### PR TITLE
Memory is not freed when create/delete large number of files.

### DIFF
--- a/xlators/encryption/crypt/src/data.c
+++ b/xlators/encryption/crypt/src/data.c
@@ -287,7 +287,7 @@ data_alloc_block(xlator_t *this, crypt_local_t *local, int32_t block_size)
 {
     struct iobuf *iobuf = NULL;
 
-    int is_iobref_new = 0;
+    gf_boolean_t is_iobref_new = _gf_false;
 
     iobuf = iobuf_get2(this->ctx->iobuf_pool, block_size);
     if (!iobuf) {
@@ -296,7 +296,7 @@ data_alloc_block(xlator_t *this, crypt_local_t *local, int32_t block_size)
     }
     if (!local->iobref_data) {
         local->iobref_data = iobref_new();
-        is_iobref_new = 1;
+        is_iobref_new = _gf_true;
         if (!local->iobref_data) {
             gf_log("crypt", GF_LOG_ERROR, "Failed to get iobref");
             iobuf_unref(iobuf);
@@ -305,7 +305,7 @@ data_alloc_block(xlator_t *this, crypt_local_t *local, int32_t block_size)
     }
     iobref_add(local->iobref_data, iobuf);
 
-    if(is_iobref_new == 1){
+    if(is_iobref_new == _gf_true){
         iobuf_unref(iobuf);
     }
 

--- a/xlators/encryption/crypt/src/data.c
+++ b/xlators/encryption/crypt/src/data.c
@@ -287,6 +287,8 @@ data_alloc_block(xlator_t *this, crypt_local_t *local, int32_t block_size)
 {
     struct iobuf *iobuf = NULL;
 
+    int is_iobref_new = 0;
+
     iobuf = iobuf_get2(this->ctx->iobuf_pool, block_size);
     if (!iobuf) {
         gf_log("crypt", GF_LOG_ERROR, "Failed to get iobuf");
@@ -294,6 +296,7 @@ data_alloc_block(xlator_t *this, crypt_local_t *local, int32_t block_size)
     }
     if (!local->iobref_data) {
         local->iobref_data = iobref_new();
+        is_iobref_new = 1;
         if (!local->iobref_data) {
             gf_log("crypt", GF_LOG_ERROR, "Failed to get iobref");
             iobuf_unref(iobuf);
@@ -301,6 +304,11 @@ data_alloc_block(xlator_t *this, crypt_local_t *local, int32_t block_size)
         }
     }
     iobref_add(local->iobref_data, iobuf);
+
+    if(is_iobref_new == 1){
+        iobuf_unref(iobuf);
+    }
+
     return iobuf->ptr;
 }
 


### PR DESCRIPTION
When iobuf is created reference count = 1. After iobref_add reference count becomes 2.
After iobref_unref it will become 1 but not zero
The above means that iobuf will not be _really_ free’ed => a memory leak.
so we would need (before return) to check if iobuf is new or not

Signed-off-by: kinsu vpolakis@gmail.com